### PR TITLE
feat: add show-location flag with config and documentation updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "gim-config"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce7334c278af8af9bd7cc2d0c53a8f48ac1a278f38de53788995a13e6e55f824"
+checksum = "74b6db802768838ec40c0da50cdeb3c5a6c2782b187ad28692fa4b76d3fb5561"
 dependencies = [
  "dirs 6.0.0",
  "toml",
@@ -441,7 +441,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git-intelligence-message"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git-intelligence-message"
-version = "1.6.0"
-edition = "2021"
+version = "1.7.0"
+edition = "2024"
 description = "An advanced Git commit message generation utility with AI assistance"
 authors = ["Sheldon.Wei<sheldon.sh.hb@gmail.com>"]
 license = "MIT"
@@ -20,7 +20,8 @@ panic = "abort"
 rustflags = ["-C", "target-feature=+crt-static"]
 
 [dependencies]
-gim-config = "0.5.0"
+gim-config = "1.0.0"
+# gim-config = { git = "https://github.com/davelet/gim-config", branch = "develop" }
 clap = { version = "4.4", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -1,4 +1,9 @@
-# Changeloga
+# Changelog
+
+## [1.7.0] - 2025-08-01
+
+- Added `--show-location` flag to command `config` to show config file location
+
 ## [1.6.1] - 2025-06-30
 
 - Added binary to scoop bucket

--- a/docs/content/user_config.md
+++ b/docs/content/user_config.md
@@ -1,7 +1,15 @@
 This feature was introduced in version `1.4.0`. Currently, only one parameter is configurable.
 
-# lines_limit
+# lines-limit
 
-`lines_limit` is an integer that limits the maximum number of lines per commit. If this limit is exceeded, the application will not execute. The default value is `1000`.
+`lines-limit` is an integer that limits the maximum number of lines per commit. If this limit is exceeded, the application will not execute. The default value is `1000`.
 
 You can configure this parameter using `gim config --lines-limit <LINES_LIMIT>`.
+
+# show-location
+Since version `1.7.0`, you can use `--show-location` flag to show config file location.
+And it opens the default file manager to the config file location.
+
+```bash
+gim config --show-location
+```

--- a/src/cli/ai_configer.rs
+++ b/src/cli/ai_configer.rs
@@ -58,7 +58,7 @@ pub fn update_ai_config(
 /// * `Ok(toml::Value)` containing the AI configuration if successful.
 /// * `Err(std::io::Error)` if the AI section is missing or invalid.
 pub fn get_ai_config() -> Result<toml::Value> {
-    let toml = config::get_config_into_toml(false);
+    let toml = config::get_config();
     if toml.is_err() {
         toml
     } else if let Ok(toml) = toml {

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -84,6 +84,10 @@ pub enum GimCommands {
     Config {
         /// Git commit changed lines limit
         #[arg(long)]
-        lines_limit: usize
+        lines_limit: Option<usize>,
+
+        /// Print config file's location
+        #[arg(long, default_value_t = false)]
+        show_location: bool
     }
 }

--- a/src/cli/custom_param.rs
+++ b/src/cli/custom_param.rs
@@ -40,7 +40,7 @@ pub fn set_lines_limit(lines_limit: usize) -> Result<()> {
         ));
         if e.kind() == ErrorKind::NotFound {
             if e.to_string() == format!("Section '{}' not found", CUSTOM_SECTION_NAME) {
-                let mut config = config::get_config_into_toml(false).unwrap();
+                let mut config = config::get_config().unwrap();
                 let map = config.as_table_mut().unwrap();
 
                 let mut update_table = Map::new();
@@ -51,6 +51,6 @@ pub fn set_lines_limit(lines_limit: usize) -> Result<()> {
         }
         return Err(e);
     }
-    print_verbose(&format!("set custom config '{}' done, value: {:?}", NAME, lines_limit));
+    println!("set custom config '{}' done, value: {:?}", NAME, lines_limit);
     Ok(())
 }

--- a/src/cli/update/reminder.rs
+++ b/src/cli/update/reminder.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, str::FromStr};
 
 use chrono::{Local, NaiveDate};
-use gim_config::config::{get_config_into_toml, update_config_value};
+use gim_config::config::{get_config, update_config_value};
 use serde::{Deserialize, Serialize};
 use toml::Value;
 
@@ -42,7 +42,7 @@ impl Default for UpdateReminder {
 
 impl UpdateReminder {
     pub fn load() -> Self {
-        let config = get_config_into_toml(false).unwrap();
+        let config = get_config().unwrap();
         let mut remider = UpdateReminder::default();
         if let Some(update) = config.get(UPDATE_SECTION) {
             if let Some(tried) = update.get("tried") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ mod constants;
 
 #[tokio::main]
 async fn main() {
-    let config = get_config().expect("Failed to access config file");
     let cli = <GimCli as clap::Parser>::parse();
     
     // Set global verbose flag
@@ -21,5 +20,6 @@ async fn main() {
     }
 
     // run the cli
+    let config = get_config().expect("Failed to access config file");
     run_cli(&cli, config).await;
 }


### PR DESCRIPTION
docs/content/changelog.md: Add 1.7.0 section with show-location flag (5)
docs/content/user_config.md: Add show-location documentation (8)
src/cli/ai_configer.rs: Replace get_config_into_toml with get_config (1)
src/cli/custom_param.rs: Replace get_config_into_toml with get_config (1)
src/cli/entry.rs: Replace get_config with get_config_and_print (1)
src/cli/update/reminder.rs: Replace get_config_into_toml with get_config (1)
src/main.rs: Replace get_config_into_toml with get_config (1)
src/cli/command.rs: Add show_location option to Config command (4)
src/cli/custom_param.rs: Change print_verbose to println (1)
src/cli/entry.rs: Add show_location handling and open config directory (13)
src/main.rs: Replace get_config with get_config_into_toml (1)